### PR TITLE
Mishap_variable = Dodge, with balance changes

### DIFF
--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -157,7 +157,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 //[/FatigueSys]
 
 //[SaberSys]
-#define MISHAP_VARIABLE			fd.forcePower	//The variable used for tracking a player's mishap level. MUST be a variable inside of the playerstate.
+#define MISHAP_VARIABLE			stats[STAT_DODGE]	//The variable used for tracking a player's mishap level. MUST be a variable inside of the playerstate.
 #define MISHAPLEVEL_FULL		5  //the point at which full mishaps occur on the balance bar.
 #define MISHAPLEVEL_HEAVY		10
 #define MISHAPLEVEL_LIGHT		25

--- a/codemp/game/bg_saber.c
+++ b/codemp/game/bg_saber.c
@@ -1281,7 +1281,9 @@ void PM_SaberLockBreak( playerState_t *genemy, qboolean victory, int strength )
 	//qboolean punishLoser = qfalse;
 	//[SaberLockSys]
 	//qboolean noKnockdown = qfalse;
-	qboolean superBreak = victory;
+	//qboolean superBreak = victory;
+	// 74145: Only do superbreak when they are low on dodge
+	qboolean superBreak = victory && (genemy->stats[STAT_DODGE] <= DODGE_CRITICALLEVEL);
 
 	//remove the saber lock winner flag.
 	pm->ps->userInt3 &= ~( 1 << FLAG_SABERLOCK_ATTACKER );
@@ -1309,10 +1311,7 @@ void PM_SaberLockBreak( playerState_t *genemy, qboolean victory, int strength )
 	if ( victory )
 	{ //someone lost the lock, so punish them by knocking them down
 		//[SaberLockSys]
-		if(!superBreak)
-		{//if we're not in a superbreak, force the loser to mishap.
-			pm->checkDuelLoss = genemy->clientNum+1;
-		}
+		pm->checkDuelLoss = genemy->clientNum+1;
 
 		//racc - this seems to override the actual saberlock completion animations I don't want that.
 		/*

--- a/codemp/game/g_active.c
+++ b/codemp/game/g_active.c
@@ -4053,19 +4053,11 @@ void ClientThink_real( gentity_t *ent ) {
 		if (pmove.checkDuelLoss > 0 && (pmove.checkDuelLoss <= MAX_CLIENTS || (pmove.checkDuelLoss < (MAX_GENTITIES-1) && g_entities[pmove.checkDuelLoss-1].s.eType == ET_NPC) ) )
 		{
 			gentity_t *clientLost = &g_entities[pmove.checkDuelLoss-1];
-
 			if (clientLost && clientLost->inuse && clientLost->client)
-			{
 				G_RollBalance(clientLost, ent, qtrue);
-			}
-		}
 
-		/* racc - don't use the basejka instant death check.  I don't like it.
-		if (pmove.checkDuelLoss > 0 && (pmove.checkDuelLoss <= MAX_CLIENTS || (pmove.checkDuelLoss < (MAX_GENTITIES-1) && g_entities[pmove.checkDuelLoss-1].s.eType == ET_NPC) ) )
-		{
-			gentity_t *clientLost = &g_entities[pm.checkDuelLoss-1];
-
-			if (clientLost && clientLost->inuse && clientLost->client && Q_irand(0, 40) > clientLost->health)
+			//if (clientLost && clientLost->inuse && clientLost->client && Q_irand(0, 40) > clientLost->health)
+			if (clientLost && clientLost->inuse && clientLost->client && clientLost->client->ps.stats[STAT_DODGE] <= DODGE_CRITICALLEVEL)
 			{
 				vec3_t attDir;
 				VectorSubtract(ent->client->ps.origin, clientLost->client->ps.origin, attDir);
@@ -4075,6 +4067,8 @@ void ClientThink_real( gentity_t *ent ) {
 				clientLost->client->ps.forceHandExtend = HANDEXTEND_NONE;
 				clientLost->client->ps.forceHandExtendTime = 0;
 
+				// 74145: Damage is ramped up in CheckSaberDamage instead.
+				/* racc - don't use the basejka instant death check.  I don't like it.
 				gGAvoidDismember = 1;
 				G_Damage(clientLost, ent, ent, attDir, clientLost->client->ps.origin, 9999, DAMAGE_NO_PROTECTION, MOD_SABER);
 
@@ -4085,6 +4079,7 @@ void ClientThink_real( gentity_t *ent ) {
 				}
 
 				gGAvoidDismember = 0;
+				*/
 			}
 			else if (clientLost && clientLost->inuse && clientLost->client &&
 				clientLost->client->ps.forceHandExtend != HANDEXTEND_KNOCKDOWN && clientLost->client->ps.saberEntityNum)
@@ -4092,7 +4087,6 @@ void ClientThink_real( gentity_t *ent ) {
 				saberCheckKnockdown_DuelLoss(&g_entities[clientLost->client->ps.saberEntityNum], clientLost, ent);
 			}
 		}
-		*/
 		//[/SaberLockSys]
 
 		pmove.checkDuelLoss = 0;

--- a/codemp/game/g_items.c
+++ b/codemp/game/g_items.c
@@ -2644,6 +2644,10 @@ int Pickup_Weapon (gentity_t *ent, gentity_t *other) {
 	G_AddEvent(other, EV_WEAPINVCHANGE, other->client->ps.stats[STAT_WEAPONS]);
 	//[/VisualWeapons]
 
+	// 74145: If you lack this weapon skill, pickup minimal ammo
+	if (!SkillLevelForWeap(other, ent->item->giTag))
+		quantity = 1;
+
 	//Add_Ammo( other, ent->item->giTag, quantity );
 	Add_Ammo( other, weaponData[ent->item->giTag].ammoIndex, quantity );
 

--- a/codemp/game/g_saberbeh.c
+++ b/codemp/game/g_saberbeh.c
@@ -94,7 +94,6 @@ qboolean SabBeh_RollBalance(gentity_t *self, sabmech_t *mechSelf, qboolean force
 extern qboolean WalkCheck( gentity_t * self );
 void G_AddMercBalance(gentity_t *self, int amount)
 {//mercs don't suffer mishaps, but they do lose/gain MP
-	/*
 	if(!WalkCheck(self))
 	{//running or moving very fast, can't balance as well
 		if(amount > 0)
@@ -109,17 +108,15 @@ void G_AddMercBalance(gentity_t *self, int amount)
 
 	//G_Printf("%i: %i: %i Mishap Points\n", level.time, self->s.number, amount);
 
-	self->client->ps.MISHAP_VARIABLE -= amount;
+	if (amount > 0 && self->client->ps.MISHAP_VARIABLE > MISHAPLEVEL_LIGHT)
+	{
+		self->client->ps.MISHAP_VARIABLE -= amount*5;
 
-	if(self->client->ps.MISHAP_VARIABLE < 0)
-	{
-		self->client->ps.MISHAP_VARIABLE = MISHAPLEVEL_NONE;
+		if(self->client->ps.MISHAP_VARIABLE < MISHAPLEVEL_LIGHT)
+		{
+			self->client->ps.MISHAP_VARIABLE = MISHAPLEVEL_LIGHT;
+		}
 	}
-	else if(self->client->ps.MISHAP_VARIABLE > MISHAPLEVEL_MAX)
-	{
-		self->client->ps.MISHAP_VARIABLE = MISHAPLEVEL_MAX;
-	}
-	*/
 }
 //[/WeapAccuracy]
 
@@ -164,7 +161,6 @@ void G_RollBalance(gentity_t *self, gentity_t *inflictor, qboolean forceMishap)
 
 void SabBeh_AddBalance(gentity_t *self, sabmech_t *mechSelf, int amount, qboolean attack)
 {
-	/*
 	if(!WalkCheck(self))
 	{//running or moving very fast, can't balance as well
 		if(amount > 0)
@@ -179,13 +175,11 @@ void SabBeh_AddBalance(gentity_t *self, sabmech_t *mechSelf, int amount, qboolea
 
 	//G_Printf("%i: %i: %i Mishap Points\n", level.time, self->s.number, amount);
 
-	self->client->ps.MISHAP_VARIABLE -= amount;
+	if (amount < 0)
+		return;
+	self->client->ps.MISHAP_VARIABLE -= amount*5;
 
 	if(self->client->ps.MISHAP_VARIABLE < 0)
-	{
-		self->client->ps.MISHAP_VARIABLE = MISHAPLEVEL_NONE;
-	}
-	else if(self->client->ps.MISHAP_VARIABLE > MISHAPLEVEL_MAX)
 	{//overflowing causes a full mishap.
 		int randNum = Q_irand(0, 2);
 		switch (randNum)
@@ -197,9 +191,8 @@ void SabBeh_AddBalance(gentity_t *self, sabmech_t *mechSelf, int amount, qboolea
 			mechSelf->doKnockdown = qtrue;
 			break;
 		};
-		self->client->ps.MISHAP_VARIABLE = MISHAPLEVEL_HEAVY;
+		self->client->ps.MISHAP_VARIABLE = 0;
 	}
-	*/
 }
 
 

--- a/codemp/game/w_saber.c
+++ b/codemp/game/w_saber.c
@@ -4911,6 +4911,12 @@ static QINLINE qboolean CheckSaberDamage(gentity_t *self, int rSaberNum, int rBl
 	{
 		dmg = DAMAGE_THROWN;
 	}
+	//[SaberLockSys]
+	else if ( BG_SuperBreakWinAnim(self->client->ps.torsoAnim) )
+	{ // 74145: instadeath damage for finishing moves
+		dmg = 9999;
+	}
+	//[/SaberLockSys]
 	else if ( BG_SaberInFullDamageMove(&self->client->ps, self->localAnimIndex) )
 	//if ( self->client->ps.saberAttackWound < level.time
 	{//full damage moves


### PR DESCRIPTION
I tried to spin a bit further on cd9a097daa5dac68: Prototyping the removal of mishap points...

My idea here is to rebrand the Dodge variable into "Balance".
Thus it would track blocking, dodge and mishaps.
In order to balance stuff out I made changes to what can be dodged:
    - saber can never be dodged, just like melee.
    - explosions can only be partially dodged (so you always take damage/get knocked).
    - only jedi and hybrid can dodge at all (need FP_SEE > 0)
    - doubled dodge cost for those without force speed (FP_SPEED == 0)

Also made weapon pickups for Jedi less rewarding, picking up a rocket launcher was too OP.

Not really balanced at all, but can be tested to get a feeling for it.